### PR TITLE
Fix Rails 7 deprecation warning on Enumerable#sum

### DIFF
--- a/lib/action_view/helpers/dynamic_form.rb
+++ b/lib/action_view/helpers/dynamic_form.rb
@@ -221,11 +221,11 @@ module ActionView
 
             message = options.include?(:message) ? options[:message] : locale.t(:body)
 
-            error_messages = objects.sum do |object|
+            error_messages = objects.map do |object|
               object.errors.full_messages.map do |msg|
                 content_tag(:li, msg)
               end
-            end.join.html_safe
+            end.inject(:+).join.html_safe
 
             contents = ''
             contents << content_tag(options[:header_tag] || :h2, header_message) unless header_message.blank?


### PR DESCRIPTION
DEPRECATION WARNING: Rails 7.0 has deprecated Enumerable.sum in favor of Ruby's native implementation available since 2.4. Sum of non-numeric elements requires an initial argument.

found equivalent by looking at implementation.
https://github.com/rails/rails/blob/a1a01842f84d113e785f21ba2b33557f2eb60b25/activesupport/lib/active_support/core_ext/enumerable.rb#L74