### PR TITLE
Handle error message possibly already being an array

### DIFF
--- a/lib/active_model/dynamic_errors.rb
+++ b/lib/active_model/dynamic_errors.rb
@@ -14,21 +14,23 @@ module ActiveModel
       full_messages = []
 
       each do |error|
-        if error.attribute == :base
-          full_messages << error.message
-        else
-          attr_name = error.attribute.to_s.gsub('.', '_').humanize
-          attr_name = @base.class.human_attribute_name(error.attribute, :default => attr_name)
-          options = { :default => "%{attribute} %{message}", :attribute => attr_name }
-
-          if error.message =~ /^\^/
-            options[:default] = "%{message}"
-            full_messages << I18n.t(:"errors.dynamic_format", **options.merge(:message => error.message[1..-1]))
-          elsif error.message.is_a? Proc
-            options[:default] = "%{message}"
-            full_messages << I18n.t(:"errors.dynamic_format", **options.merge(:message => error.message.call(@base)))
+        Array.wrap(error.message).each do |error_message|
+          if error.attribute == :base
+            full_messages << error_message
           else
-            full_messages << I18n.t(:"errors.format", **options.merge(:message => error.message))
+            attr_name = error.attribute.to_s.gsub('.', '_').humanize
+            attr_name = @base.class.human_attribute_name(error.attribute, :default => attr_name)
+            options = { :default => "%{attribute} %{message}", :attribute => attr_name }
+
+            if error_message =~ /^\^/
+              options[:default] = "%{message}"
+              full_messages << I18n.t(:"errors.dynamic_format", **options.merge(:message => error_message[1..-1]))
+            elsif error_message.is_a? Proc
+              options[:default] = "%{message}"
+              full_messages << I18n.t(:"errors.dynamic_format", **options.merge(:message => error_message.call(@base)))
+            else
+              full_messages << I18n.t(:"errors.format", **options.merge(:message => error_message))
+            end
           end
         end
       end


### PR DESCRIPTION
I ran into an issue upgrading dynamic_form on an older application. I think [the commit](https://github.com/payrollhero/dynamic_form/commit/bd9d4d9d92e724340be5f13e8b239537f29e2d90) that made the library compatible with newer versions of rails inadvertently removed support for certain kinds of association validations.

It removed the `messages = Array.wrap(messages)` casting that handled error messages whether they were already an array or not.

I don't have a standalone reproducible example but I wanted to open this PR anyway in case anyone else runs into the same problem.

The diff is much clearer if you hide whitespace (https://github.com/payrollhero/dynamic_form/pull/5/files?diff=unified&w=1).