### PR TITLE
Drop Rails 5.2 as EOL

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,8 +20,6 @@ jobs:
         include:
           - gemfile: rails_6.0
             ruby: 2.7
-          - gemfile: rails_5.2
-            ruby: 2.7
 
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile

--- a/dynamic_form.gemspec
+++ b/dynamic_form.gemspec
@@ -42,8 +42,8 @@ Gem::Specification.new do |s|
      "test/test_helper.rb"
   ]
 
-  s.add_runtime_dependency 'actionview', '> 5.2.0'
-  s.add_runtime_dependency 'activemodel', '> 5.2.0'
+  s.add_runtime_dependency 'actionview', '>= 6.0.0'
+  s.add_runtime_dependency 'activemodel', '>= 6.0.0'
   s.add_development_dependency(%q<benchmark>, [">= 0"])
   s.add_development_dependency(%q<bigdecimal>, [">= 0"])
   s.add_development_dependency(%q<byebug>, [">= 0"])

--- a/dynamic_form.gemspec
+++ b/dynamic_form.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = %q{dynamic_form}
-  s.version = "1.3.3"
+  s.version = "1.4.0"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.required_ruby_version = ">= 2.7.0", "< 3.5"

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-source "https://rubygems.org"
-
-gem "rails", "~> 5.2.6"
-gem "sqlite3", "~> 1.4.1"
-
-gemspec path: "../"


### PR DESCRIPTION
Noticed while checking if https://github.com/payrollhero/dynamic_form/pull/9 was published to rubygems.org (it isn't or it's been yanked)


https://endoflife.date/rails

<img width="1012" height="961" alt="image" src="https://github.com/user-attachments/assets/8aea98b2-a694-4416-9024-23ea68191c33" />

This ... very gently... drops Rails 5.2 support.
Subsequent changes can drop other EOL versions.