### PR TITLE
Add Rails 7.2 to build matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,8 @@ jobs:
         gemfile: ['rails_7.1', 'rails_7.0', 'rails_6.1']
         ruby: [3.4, 3.3, 3.2, 3.1, '3.0', 2.7]
         include:
+          - gemfile: rails_7.2
+            ruby: 3.1
           - gemfile: rails_6.0
             ruby: 2.7
           - gemfile: rails_5.2

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "rails", "~> 7.2.0"
+gem "sqlite3"
+
+gemspec path: "../"


### PR DESCRIPTION
Adds Rails 7.2 support to build matrix.
Didn't modify the semver yet with this one, as I figured the deprecations are better to go in first.
