### PR TITLE
Refactor to fix warnings around frozen strings

### DIFF
--- a/lib/action_view/helpers/dynamic_form.rb
+++ b/lib/action_view/helpers/dynamic_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'action_view/helpers'
 require 'active_support/i18n'
 require 'active_support/core_ext/enumerable'

--- a/lib/action_view/helpers/dynamic_form.rb
+++ b/lib/action_view/helpers/dynamic_form.rb
@@ -234,12 +234,12 @@ module ActionView
               end
             end.inject(:+).join.html_safe
 
-            contents = ''
+            contents = ''.html_safe
             contents << content_tag(options[:header_tag] || :h2, header_message) unless header_message.blank?
             contents << content_tag(:p, message) unless message.blank?
             contents << content_tag(:ul, error_messages)
 
-            content_tag(:div, contents.html_safe, html)
+            content_tag(:div, contents, html)
           end
         else
           ''


### PR DESCRIPTION
When running tests, there were a number of warnings about modifying a frozen string.

Turns out, we can just rewrite this to be a ActiveRecord::SafeBuffer, which is safe to mutate.
```
@CloCkWeRX ➜ /workspaces/dynamic_form (html-safe) $ bundle exec rake test
Loaded suite /usr/local/rvm/gems/ruby-3.4.1/gems/rake-13.3.0/lib/rake/rake_test_loader
Started
Finished in 0.083011199 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------
31 tests, 44 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------
373.44 tests/s, 530.05 assertions/s
```
